### PR TITLE
Support amqps broker URLs

### DIFF
--- a/flower/utils/broker.py
+++ b/flower/utils/broker.py
@@ -230,9 +230,19 @@ class RedisSsl(Redis):
 
 
 class Broker:
+    """Factory returning the appropriate broker client based on URL scheme.
+
+    Supported schemes:
+    ``amqp`` or ``amqps``  -> :class:`RabbitMQ`
+    ``redis``              -> :class:`Redis`
+    ``rediss``             -> :class:`RedisSsl`
+    ``redis+socket``       -> :class:`RedisSocket`
+    ``sentinel``           -> :class:`RedisSentinel`
+    """
+
     def __new__(cls, broker_url, *args, **kwargs):
         scheme = urlparse(broker_url).scheme
-        if scheme == 'amqp':
+        if scheme in ('amqp', 'amqps'):
             return RabbitMQ(broker_url, *args, **kwargs)
         if scheme == 'redis':
             return Redis(broker_url, *args, **kwargs)

--- a/tests/unit/utils/test_broker.py
+++ b/tests/unit/utils/test_broker.py
@@ -11,9 +11,10 @@ broker.redis = MagicMock()
 
 class TestRabbitMQ(unittest.TestCase):
     def test_init(self):
-        b = Broker('amqp://', '')
-        self.assertTrue(isinstance(b, RabbitMQ))
-        self.assertFalse(isinstance(b, Redis))
+        for url in ['amqp://', 'amqps://']:
+            b = Broker(url, '')
+            self.assertTrue(isinstance(b, RabbitMQ))
+            self.assertFalse(isinstance(b, Redis))
 
     def test_url(self):
         b = RabbitMQ('amqp://user:pass@host:10000/vhost', '')
@@ -32,7 +33,7 @@ class TestRabbitMQ(unittest.TestCase):
         self.assertEqual('pass', b.password)
 
     def test_url_defaults_rabbitmq(self):
-        for url in ['amqp://', 'amqp://localhost']:
+        for url in ['amqp://', 'amqp://localhost', 'amqps://', 'amqps://localhost']:
             b = RabbitMQ(url, '')
             self.assertEqual('localhost', b.host)
             self.assertEqual(15672, b.port)


### PR DESCRIPTION
## Summary
- handle `amqps` scheme in broker factory
- document supported broker schemes
- test RabbitMQ factory with amqps

## Testing
- `pytest -q tests/unit/utils/test_broker.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68403e11b184832bb0a451c536e5f614